### PR TITLE
Script Caps lock to escape

### DIFF
--- a/install
+++ b/install
@@ -15,6 +15,8 @@ then
   git clone git@github.com:samlawrencejones/dotfiles.git ~/code/dotfiles || echo "Generate/Upload SSH Key To Github: https://help.github.com/articles/generating-ssh-keys/"
 fi
 
+## set script that runs every login to set env preferences
+sudo defaults write com.apple.loginwindow LoginHook <path_to_login_script>
 
 # Install Homebrew
 if ! which brew >/dev/null


### PR DESCRIPTION
I noticed in your readme you mentioned something about this.

If you want to totally disable caps lock, you may be able to still do something similar.

To get it working:

Create a script that line 19 of `install` will point to containing the following line:

```##set caps lock to escape
hidutil property --set '{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x700000039,"HIDKeyboardModifierMappingDst":0x700000029}]}'
```

Simply running the command doesn't seem to persist after a reboot, so this method will allow for the changes to persist by running the script at login. 

Hope this helps, and if it isn't what you're looking for, then no worries!